### PR TITLE
Add package.json and simple health test

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,83 @@
+{
+  "name": "beekeeping-voice-system",
+  "version": "1.0.0",
+  "description": "牛角瓜蜂場GAP語音管理系統",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "dev": "nodemon server.js",
+    "test": "jest",
+    "lint": "eslint .",
+    "build": "npm run build:client",
+    "build:client": "webpack --mode production",
+    "docker:build": "docker build -t beekeeping-voice-system .",
+    "docker:run": "docker-compose up -d",
+    "docker:stop": "docker-compose down",
+    "migrate": "knex migrate:latest",
+    "seed": "knex seed:run"
+  },
+  "keywords": [
+    "beekeeping",
+    "voice-recognition",
+    "gap-certification",
+    "agriculture",
+    "taiwan",
+    "honey",
+    "line-bot"
+  ],
+  "author": "蜂場管理系統開發團隊",
+  "license": "MIT",
+  "dependencies": {
+    "@line/bot-sdk": "^7.5.2",
+    "axios": "^1.6.2",
+    "cors": "^2.8.5",
+    "dotenv": "^16.3.1",
+    "express": "^4.18.2",
+    "express-rate-limit": "^7.1.5",
+    "form-data": "^4.0.0",
+    "helmet": "^7.1.0",
+    "ioredis": "^5.3.2",
+    "joi": "^17.11.0",
+    "jsonwebtoken": "^9.0.2",
+    "knex": "^3.0.1",
+    "lodash": "^4.17.21",
+    "moment": "^2.29.4",
+    "moment-timezone": "^0.5.43",
+    "morgan": "^1.10.0",
+    "multer": "^1.4.5-lts.1",
+    "node-cron": "^3.0.3",
+    "openai": "^4.20.1",
+    "pg": "^8.11.3",
+    "sharp": "^0.32.6",
+    "uuid": "^9.0.1",
+    "winston": "^3.11.0"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.23.5",
+    "@babel/preset-env": "^7.23.5",
+    "babel-loader": "^9.1.3",
+    "css-loader": "^6.8.1",
+    "eslint": "^8.54.0",
+    "html-webpack-plugin": "^5.5.3",
+    "jest": "^29.7.0",
+    "mini-css-extract-plugin": "^2.7.6",
+    "nodemon": "^3.0.1",
+    "style-loader": "^3.3.3",
+    "supertest": "^6.3.3",
+    "webpack": "^5.89.0",
+    "webpack-cli": "^5.1.4",
+    "webpack-dev-server": "^4.15.1"
+  },
+  "engines": {
+    "node": ">=18.0.0",
+    "npm": ">=8.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/your-org/beekeeping-voice-system.git"
+  },
+  "bugs": {
+    "url": "https://github.com/your-org/beekeeping-voice-system/issues"
+  },
+  "homepage": "https://github.com/your-org/beekeeping-voice-system#readme"
+}

--- a/server.test.js
+++ b/server.test.js
@@ -1,0 +1,12 @@
+process.env.OPENAI_API_KEY = "test";
+process.env.CHANNEL_ACCESS_TOKEN = "test"; process.env.CHANNEL_SECRET = "test";
+const request = require('supertest');
+const app = require('./server');
+
+describe('GET /health', () => {
+  it('returns health status', async () => {
+    const res = await request(app).get('/health');
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('OK');
+  });
+});


### PR DESCRIPTION
## Summary
- include package.json for node dependencies and scripts
- add a minimal Jest test covering the `/health` endpoint

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68418c5d66fc8324b7373daad95a50f5