### PR TITLE
Add env sample and dotenv support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,63 @@
+# ===========================================
+# \u725b\u89d2\u74dc\u8702\u5834GAP\u8a9e\u97f3\u7ba1\u7406\u7cfb\u7d71 - \u74b0\u5883\u8b8a\u6578\u8a2d\u5b9a
+# ===========================================
+
+# \u57fa\u672c\u8a2d\u5b9a
+NODE_ENV=production
+PORT=3000
+APP_NAME=beekeeping-voice-system
+APP_VERSION=1.0.0
+
+# LINE Bot \u8a2d\u5b9a
+CHANNEL_ACCESS_TOKEN=your_line_channel_access_token_here
+CHANNEL_SECRET=your_line_channel_secret_here
+LINE_NOTIFY_TOKEN=your_line_notify_token_here
+
+# OpenAI API \u8a2d\u5b9a
+OPENAI_API_KEY=your_openai_api_key_here
+OPENAI_MODEL=gpt-4
+WHISPER_MODEL=whisper-1
+
+# \u8cc7\u6599\u5eab\u8a2d\u5b9a
+DB_HOST=localhost
+DB_PORT=5432
+DB_NAME=beekeeping
+DB_USER=postgres
+DB_PASSWORD=your_strong_password_here
+POSTGRES_PASSWORD=your_strong_password_here
+
+# Redis \u8a2d\u5b9a
+REDIS_HOST=localhost
+REDIS_PORT=6379
+REDIS_PASSWORD=
+REDIS_DB=0
+
+# Google Sheets API \u8a2d\u5b9a
+GOOGLE_SHEET_ID=your_google_sheet_id_here
+GOOGLE_SERVICE_ACCOUNT_EMAIL=your_service_account@your-project.iam.gserviceaccount.com
+GOOGLE_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\nyour_private_key_here\n-----END PRIVATE KEY-----"
+
+# n8n \u5de5\u4f5c\u6d41\u8a2d\u5b9a
+N8N_WEBHOOK_URL=http://localhost:5678/webhook/beekeeping-webhook
+N8N_PASSWORD=your_n8n_admin_password_here
+N8N_HOST=localhost
+N8N_PORT=5678
+
+# \u6a94\u6848\u5132\u5b58\u8a2d\u5b9a (MinIO)
+MINIO_ENDPOINT=localhost
+MINIO_PORT=9000
+MINIO_ACCESS_KEY=minioadmin
+MINIO_SECRET_KEY=your_minio_secret_key_here
+MINIO_BUCKET=beekeeping-files
+
+# JWT \u8a2d\u5b9a
+JWT_SECRET=your_jwt_secret_key_here
+JWT_EXPIRES_IN=7d
+
+# \u76e3\u63a7\u8a2d\u5b9a
+GRAFANA_PASSWORD=your_grafana_password_here
+
+# \u90f5\u4ef6\u8a2d\u5b9a (\u7528\u65bc\u901a\u77e5)
+SMTP_HOST=smtp.gmail.com
+SMTP_PORT=587
+SMTP_USER=

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+.env

--- a/README.md
+++ b/README.md
@@ -24,3 +24,13 @@ For development you can use the `development` stage:
 docker build -t beekeeping-voice-system-dev --target development .
 docker run -p 3000:3000 beekeeping-voice-system-dev
 ```
+
+## Environment Variables
+
+Copy `.env.example` to `.env` and fill in your credentials before running the server locally.
+
+```bash
+cp .env.example .env
+```
+
+The application loads these values at startup using `dotenv`.

--- a/server.js
+++ b/server.js
@@ -5,6 +5,7 @@ const axios = require('axios');
 const fs = require('fs');
 const path = require('path');
 const FormData = require('form-data');
+require('dotenv').config();
 
 // 設定
 const app = express();


### PR DESCRIPTION
## Summary
- add `.env.example` with placeholder config values
- ignore `.env` so local secrets aren't committed
- document env setup steps in README
- load environment from `.env` in the server

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841925664988324bd04529ed5cfc2fe